### PR TITLE
Nginx w3tc_rewrite_test bug

### DIFF
--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -815,7 +815,7 @@ class PgCache_Environment {
 		$rules = '';
 		$rules .= W3TC_MARKER_BEGIN_PGCACHE_CORE . "\n";
 		if ( $config->get_boolean( 'pgcache.debug' ) ) {
-			$rules .= "rewrite ^(.*\\/)?w3tc_rewrite_test([0-9]+)/?$ $1?w3tc_rewrite_test=1 last;\n";
+			$rules .= "rewrite ^(.*\\/)?w3tc_rewrite_test([a-z0-9]+)/?$ $1?w3tc_rewrite_test=1 last;\n";
 		}
 
 		/**


### PR DESCRIPTION
When the plugin try to test if the cache working it request a test url, eg:
http://example.org/45fgf56w3tc_rewrite_test.css

it request is handled by the following rule:

```
rewrite ^(.*\/)?w3tc_rewrite_test([0-9]+)/?$ $1?w3tc_rewrite_test=1 last;
```

The rule above doesn’t match with the test URL
